### PR TITLE
added support for numeric ids in _valueChanged handler

### DIFF
--- a/lib/gridUtils.js
+++ b/lib/gridUtils.js
@@ -44,7 +44,7 @@ module.exports = function (options) {
         _valueChanged: function (rowId, colId, value) {
             var column = _.findWhere(options.columns, {id: colId});
             var id = {};
-            id[options.id] = _.isNaN(rowId) ? rowId : Number(rowId);
+            id[options.id] = isNaN(rowId) ? rowId : Number(rowId);
             var obj = _.findWhere(options.data, id);
             var parsedValue = column.parser(colId, value);
             setValue(colId, obj, parsedValue);

--- a/lib/gridUtils.js
+++ b/lib/gridUtils.js
@@ -44,7 +44,7 @@ module.exports = function (options) {
         _valueChanged: function (rowId, colId, value) {
             var column = _.findWhere(options.columns, {id: colId});
             var id = {};
-            id[options.id] = rowId;
+            id[options.id] = _.isNaN(rowId) ? rowId : Number(rowId);
             var obj = _.findWhere(options.data, id);
             var parsedValue = column.parser(colId, value);
             setValue(colId, obj, parsedValue);


### PR DESCRIPTION
I added support for numeric id's in _valueChanged handler. The original implementation crashed with numeric id's instead of string values. I'm using this grid in combination with a MySQL database and numeric keys. So this could be helpful to someone else as well.